### PR TITLE
feat(module-core): 实现 ihub-module-core 模块描述符基础设施

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ JSON Schema: [`schema/module-descriptor-v1.json`](schema/module-descriptor-v1.js
 | 模块 | 状态 | 描述 |
 |------|------|------|
 | `ihub-module-core` | 实验性 | 模块基础设施：描述符模型、注册表、Jackson 序列化 |
-| `ihub-module-iam` | 规划中 | IAM 模块：用户/角色/权限管理 |
+| `ihub-module-iam` | 实验性 | IAM 模块：用户/角色/权限管理（内存实现 + Spring Boot 自动配置） |
 
 ### 🤖 AI 编排能力
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,40 @@
     </a>
 </p>
 
-通用业务模块组件库
+## IHub 业务蓝图层（L2 Capability Board）
+
+IHub 三层架构中的 **业务蓝图层**，提供即插即用的通用业务模块，每个模块携带 AI 可编排的结构化描述符。
+
+### 🧩 模块描述符规范
+
+每个业务模块在 `META-INF/ihub/module-descriptor.json` 提供结构化元数据，AI 工具可通过 MCP Server 发现并编排这些模块：
+
+```json
+{
+  "id": "iam-user",
+  "domain": "iam",
+  "capabilities": [...],    // API、事件、定时任务
+  "mcp_tools": [...]        // AI 可直接调用的操作
+}
+```
+
+JSON Schema: [`schema/module-descriptor-v1.json`](schema/module-descriptor-v1.json)
+
+### 📦 核心模块
+
+| 模块 | 状态 | 描述 |
+|------|------|------|
+| `ihub-module-core` | 实验性 | 模块基础设施：描述符模型、注册表、Jackson 序列化 |
+| `ihub-module-iam` | 规划中 | IAM 模块：用户/角色/权限管理 |
+
+### 🤖 AI 编排能力
+
+通过 `agents/mcp-server` 的 `ModuleTools`，AI 工具可：
+- `listModules()` — 列出所有可用业务模块
+- `getModule(moduleId)` — 获取模块详细描述符
+- `getModuleTools(moduleId)` — 获取模块的 MCP 工具列表
+
+> 详细设计：[P2 MCP 编排规范](https://github.com/ihub-pub/ihub/blob/main/docs/strategy/2026-05-04-ihub-modules-p2-design.md)
 
 ## 🧭 开源贡献指南
 

--- a/ihub-module-core/build.gradle.kts
+++ b/ihub-module-core/build.gradle.kts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+description = "IHub 业务模块核心基础设施"
+
+dependencies {
+    api("com.fasterxml.jackson.core:jackson-databind")
+    compileOnly("org.springframework.boot:spring-boot-autoconfigure")
+
+    testImplementation("org.springframework.boot:spring-boot-autoconfigure")
+}

--- a/ihub-module-core/src/main/java/pub/ihub/module/core/McpToolDefinition.java
+++ b/ihub-module-core/src/main/java/pub/ihub/module/core/McpToolDefinition.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.module.core;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+/**
+ * MCP 工具定义。
+ *
+ * <p>描述业务模块暴露给 AI 工具的单个 MCP 操作。
+ * AI 工具（Claude / Cursor 等）通过 MCP Server 发现并调用这些工具。
+ *
+ * @param name         工具名称（全局唯一，供 AI 调用）
+ * @param description  工具描述（AI 理解工具用途的依据）
+ * @param inputSchema  输入参数结构
+ * @param outputSchema 输出结果结构
+ * @author IHub
+ * @since 0.1.0
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record McpToolDefinition(
+        String name,
+        String description,
+        @JsonProperty("input_schema") Map<String, Object> inputSchema,
+        @JsonProperty("output_schema") Map<String, Object> outputSchema
+) {}

--- a/ihub-module-core/src/main/java/pub/ihub/module/core/ModuleCapability.java
+++ b/ihub-module-core/src/main/java/pub/ihub/module/core/ModuleCapability.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.module.core;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+/**
+ * 模块能力描述。
+ *
+ * <p>能力是模块对外提供的单个功能单元，可以是 REST API、领域事件、定时任务或 MCP 工具。
+ *
+ * @param id          能力唯一 ID，如 {@code "user.create"}
+ * @param name        能力名称
+ * @param type        能力类型
+ * @param description AI 可读描述
+ * @param inputSchema 输入参数结构（JSON Schema 片段）
+ * @param outputSchema 输出结果结构（JSON Schema 片段）
+ * @author IHub
+ * @since 0.1.0
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ModuleCapability(
+        String id,
+        String name,
+        CapabilityType type,
+        String description,
+        @JsonProperty("input_schema") Map<String, Object> inputSchema,
+        @JsonProperty("output_schema") Map<String, Object> outputSchema
+) {
+
+    /**
+     * 能力类型。
+     */
+    public enum CapabilityType {
+        /** REST API */
+        api,
+        /** 领域事件（Spring ApplicationEvent / 消息队列） */
+        event,
+        /** 定时任务 */
+        schedule,
+        /** MCP 工具（AI 可直接调用） */
+        mcp_tool
+    }
+}

--- a/ihub-module-core/src/main/java/pub/ihub/module/core/ModuleDependency.java
+++ b/ihub-module-core/src/main/java/pub/ihub/module/core/ModuleDependency.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.module.core;
+
+/**
+ * 模块间依赖声明。
+ *
+ * @param moduleId 依赖的模块 ID
+ * @param required 是否必须（false 表示可选）
+ * @param reason   依赖原因（AI 可读）
+ * @author IHub
+ * @since 0.1.0
+ */
+public record ModuleDependency(
+        String moduleId,
+        boolean required,
+        String reason
+) {}

--- a/ihub-module-core/src/main/java/pub/ihub/module/core/ModuleDescriptor.java
+++ b/ihub-module-core/src/main/java/pub/ihub/module/core/ModuleDescriptor.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.module.core;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 业务模块描述符。
+ *
+ * <p>每个 IHub 业务模块在 classpath 根目录下提供 {@code module-descriptor.json}，
+ * 描述其能力、依赖和 MCP 工具接口。AI 工具通过 MCP Server 读取并编排这些模块。
+ *
+ * @param id            模块唯一标识，如 {@code "iam-user"}
+ * @param name          模块名称
+ * @param nameEn        英文名称
+ * @param version       模块版本
+ * @param domain        所属业务领域，如 {@code "iam"}
+ * @param description   一句话描述
+ * @param aiContext     面向 LLM 的详细上下文（集成方式、API 清单、配置要点）
+ * @param capabilities  模块提供的能力列表
+ * @param dependencies  模块间依赖声明
+ * @param maven         Maven 坐标
+ * @param gradleRef     libs.versions.toml 别名
+ * @param configPrefix  Spring 配置前缀，如 {@code "ihub.module.user"}
+ * @param starterClass  自动配置类全名
+ * @param tags          标签列表
+ * @param status        模块状态
+ * @param mcpTools      AI 可调用的 MCP 工具列表
+ * @author IHub
+ * @since 0.1.0
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ModuleDescriptor(
+        String id,
+        String name,
+        @JsonProperty("name_en") String nameEn,
+        String version,
+        String domain,
+        String description,
+        @JsonProperty("ai_context") String aiContext,
+        List<ModuleCapability> capabilities,
+        List<ModuleDependency> dependencies,
+        Map<String, String> maven,
+        @JsonProperty("gradle_ref") String gradleRef,
+        @JsonProperty("config_prefix") String configPrefix,
+        @JsonProperty("starter_class") String starterClass,
+        List<String> tags,
+        ModuleStatus status,
+        @JsonProperty("mcp_tools") List<McpToolDefinition> mcpTools
+) {
+
+    /**
+     * 模块状态。
+     */
+    public enum ModuleStatus {
+        /** 规划中，尚未实现 */
+        planned,
+        /** 实验性，API 可能变化 */
+        experimental,
+        /** 生产就绪 */
+        stable,
+        /** 已弃用，避免新项目使用 */
+        deprecated
+    }
+}

--- a/ihub-module-core/src/main/java/pub/ihub/module/core/ModuleRegistry.java
+++ b/ihub-module-core/src/main/java/pub/ihub/module/core/ModuleRegistry.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.module.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 业务模块注册表。
+ *
+ * <p>扫描 classpath 中所有 {@code module-descriptor.json} 文件，
+ * 加载并缓存 {@link ModuleDescriptor}。供 MCP Server 的 {@code ModuleTools} 使用。
+ *
+ * <p>模块描述符文件约定放置在各模块 jar 包的根路径，命名格式：
+ * {@code META-INF/ihub/module-descriptor.json}
+ *
+ * @author IHub
+ * @since 0.1.0
+ */
+public class ModuleRegistry {
+
+    static final String DESCRIPTOR_PATH = "META-INF/ihub/module-descriptor.json";
+
+    private final Map<String, ModuleDescriptor> modules = new ConcurrentHashMap<>();
+    private final ObjectMapper objectMapper;
+
+    public ModuleRegistry(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * 手动注册一个模块描述符（用于测试或动态注册）。
+     */
+    public void register(ModuleDescriptor descriptor) {
+        modules.put(descriptor.id(), descriptor);
+    }
+
+    /**
+     * 从 classpath 中扫描并加载所有模块描述符。
+     *
+     * <p>每个 IHub 模块 jar 包在 {@code META-INF/ihub/module-descriptor.json} 放置描述符。
+     */
+    public void scanClasspath() {
+        try {
+            var resources = getClassLoader().getResources(DESCRIPTOR_PATH);
+            while (resources.hasMoreElements()) {
+                var url = resources.nextElement();
+                try (InputStream is = url.openStream()) {
+                    var descriptor = objectMapper.readValue(is, ModuleDescriptor.class);
+                    modules.put(descriptor.id(), descriptor);
+                } catch (IOException e) {
+                    // 单个描述符加载失败不影响其他模块
+                    System.err.println("Failed to load module descriptor from: " + url + " - " + e.getMessage());
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to scan module descriptors", e);
+        }
+    }
+
+    /**
+     * 获取所有已注册模块。
+     */
+    public List<ModuleDescriptor> listAll() {
+        return Collections.unmodifiableList(new ArrayList<>(modules.values()));
+    }
+
+    /**
+     * 按 ID 获取模块。
+     */
+    public Optional<ModuleDescriptor> findById(String moduleId) {
+        return Optional.ofNullable(modules.get(moduleId));
+    }
+
+    /**
+     * 按领域过滤模块。
+     */
+    public List<ModuleDescriptor> findByDomain(String domain) {
+        return modules.values().stream()
+                .filter(m -> domain.equals(m.domain()))
+                .toList();
+    }
+
+    /**
+     * 返回用于扫描 classpath 的 ClassLoader，子类可覆写以便测试。
+     */
+    protected ClassLoader getClassLoader() {
+        return getClass().getClassLoader();
+    }
+}

--- a/ihub-module-core/src/test/java/pub/ihub/module/core/ModuleRegistryTest.java
+++ b/ihub-module-core/src/test/java/pub/ihub/module/core/ModuleRegistryTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.module.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ModuleRegistryTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ModuleRegistry registry = new ModuleRegistry(objectMapper);
+
+    @Test
+    void registerAndList() {
+        ModuleDescriptor descriptor = new ModuleDescriptor(
+            "iam-user", "用户管理", "User Management", "0.1.0",
+            "iam", "用户注册、登录、档案管理", null,
+            List.of(), List.of(), Map.of("group", "pub.ihub.module", "artifact", "ihub-module-iam"),
+            "ihub-module-iam", "ihub.module.user", null,
+            List.of("iam", "user"), ModuleDescriptor.ModuleStatus.planned, List.of()
+        );
+
+        registry.register(descriptor);
+
+        assertEquals(1, registry.listAll().size());
+        assertTrue(registry.findById("iam-user").isPresent());
+        assertEquals(1, registry.findByDomain("iam").size());
+        assertTrue(registry.findByDomain("org").isEmpty());
+    }
+
+    @Test
+    void findByIdNotFound() {
+        assertTrue(registry.findById("non-existent").isEmpty());
+    }
+
+    @Test
+    void scanClasspathLoadsDescriptor() {
+        // classpath 中有 src/test/resources/META-INF/ihub/module-descriptor.json
+        registry.scanClasspath();
+
+        assertTrue(registry.findById("test-module").isPresent());
+        ModuleDescriptor m = registry.findById("test-module").get();
+        assertEquals("测试模块", m.name());
+        assertEquals("test", m.domain());
+        assertEquals(ModuleDescriptor.ModuleStatus.experimental, m.status());
+    }
+
+    @Test
+    void scanClasspathFindByDomain() {
+        registry.scanClasspath();
+        assertFalse(registry.findByDomain("test").isEmpty());
+    }
+
+    @Test
+    void allModuleStatusValues() {
+        for (ModuleDescriptor.ModuleStatus status : ModuleDescriptor.ModuleStatus.values()) {
+            assertNotNull(status.name());
+        }
+    }
+
+    @Test
+    void allCapabilityTypes() {
+        for (ModuleCapability.CapabilityType type : ModuleCapability.CapabilityType.values()) {
+            assertNotNull(type.name());
+        }
+    }
+
+    @Test
+    void moduleDependencyFields() {
+        ModuleDependency dep = new ModuleDependency("some-module", true, "需要认证能力");
+        assertEquals("some-module", dep.moduleId());
+        assertTrue(dep.required());
+        assertFalse(new ModuleDependency("opt", false, "可选").required());
+    }
+
+    @Test
+    void mcpToolDefinitionFields() {
+        McpToolDefinition tool = new McpToolDefinition("createUser", "创建用户", Map.of(), Map.of());
+        assertEquals("createUser", tool.name());
+        assertEquals("创建用户", tool.description());
+    }
+
+    @Test
+    void scanClasspathSingleDescriptorIoException() throws Exception {
+        // 模拟单个描述符加载失败时不影响其他模块（通过 broken InputStream）
+        ObjectMapper brokenMapper = new ObjectMapper() {
+            @Override
+            public <T> T readValue(java.io.InputStream src, Class<T> valueType) throws java.io.IOException {
+                throw new java.io.IOException("Simulated parse error");
+            }
+        };
+        ModuleRegistry reg = new ModuleRegistry(brokenMapper);
+        // 不抛异常，仅打印错误日志，registry 仍为空
+        assertDoesNotThrow(reg::scanClasspath);
+        assertTrue(reg.listAll().isEmpty());
+    }
+
+    @Test
+    void scanClasspathGetResourcesIoException() {
+        // 模拟 ClassLoader.getResources 抛出 IOException
+        ModuleRegistry reg = new ModuleRegistry(objectMapper) {
+            @Override
+            protected ClassLoader getClassLoader() {
+                return new ClassLoader(Thread.currentThread().getContextClassLoader()) {
+                    @Override
+                    public java.util.Enumeration<java.net.URL> getResources(String name) throws java.io.IOException {
+                        throw new java.io.IOException("Simulated ClassLoader error");
+                    }
+                };
+            }
+        };
+        RuntimeException ex = assertThrows(RuntimeException.class, reg::scanClasspath);
+        assertTrue(ex.getMessage().contains("Failed to scan module descriptors"));
+    }
+}

--- a/ihub-module-core/src/test/resources/META-INF/ihub/module-descriptor.json
+++ b/ihub-module-core/src/test/resources/META-INF/ihub/module-descriptor.json
@@ -1,0 +1,20 @@
+{
+  "id": "test-module",
+  "name": "测试模块",
+  "name_en": "Test Module",
+  "version": "0.1.0",
+  "domain": "test",
+  "description": "用于单元测试的模块描述符",
+  "ai_context": "测试专用，无需集成",
+  "capabilities": [],
+  "dependencies": [],
+  "maven": {
+    "group": "pub.ihub.module",
+    "artifact": "ihub-module-test"
+  },
+  "gradle_ref": "ihub-module-test",
+  "config_prefix": "ihub.module.test",
+  "tags": ["test"],
+  "status": "experimental",
+  "mcp_tools": []
+}

--- a/ihub-module-iam/build.gradle.kts
+++ b/ihub-module-iam/build.gradle.kts
@@ -17,4 +17,12 @@ description = "IHub IAM 模块（用户/角色/权限）"
 
 dependencies {
     implementation(project(":ihub-module-core"))
+    compileOnly("org.springframework.boot:spring-boot-autoconfigure")
+    compileOnly("com.fasterxml.jackson.core:jackson-databind")
+
+    testImplementation("org.springframework.boot:spring-boot-autoconfigure")
+    testImplementation("com.fasterxml.jackson.core:jackson-databind")
+    testImplementation("org.springframework.boot:spring-boot-test")
+    testImplementation("org.springframework:spring-test")
+    testImplementation("org.assertj:assertj-core")
 }

--- a/ihub-module-iam/build.gradle.kts
+++ b/ihub-module-iam/build.gradle.kts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+description = "IHub IAM 模块（用户/角色/权限）"
+
+dependencies {
+    implementation(project(":ihub-module-core"))
+}

--- a/ihub-module-iam/src/main/java/pub/ihub/module/iam/IHubIamAutoConfiguration.java
+++ b/ihub-module-iam/src/main/java/pub/ihub/module/iam/IHubIamAutoConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.module.iam;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * IHub IAM 模块自动配置。
+ *
+ * <p>当 classpath 中引入 {@code ihub-module-iam} 且未自定义 {@link UserService} 时，
+ * 自动注册内存实现的 {@link UserService}。
+ *
+ * <p>生产环境应提供持久化实现的 {@link UserService} Bean 以覆盖此默认实现。
+ *
+ * @author IHub
+ * @since 0.1.0
+ */
+@AutoConfiguration
+public class IHubIamAutoConfiguration {
+
+    /**
+     * 注册内存版 {@link UserService}（仅当未提供自定义实现时）。
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public UserService userService() {
+        return new UserService();
+    }
+}

--- a/ihub-module-iam/src/main/java/pub/ihub/module/iam/User.java
+++ b/ihub-module-iam/src/main/java/pub/ihub/module/iam/User.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.module.iam;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * 用户账号领域对象。
+ *
+ * @param userId    用户唯一 ID
+ * @param username  用户名（全局唯一）
+ * @param email     邮箱地址（可选）
+ * @param status    账号状态
+ * @param roles     已分配角色 ID 列表
+ * @param createdAt 创建时间
+ * @author IHub
+ * @since 0.1.0
+ */
+public record User(
+        String userId,
+        String username,
+        String email,
+        UserStatus status,
+        List<String> roles,
+        Instant createdAt
+) {
+
+    /**
+     * 用户账号状态。
+     */
+    public enum UserStatus {
+        /** 待激活（注册后未验证邮箱） */
+        PENDING,
+        /** 活跃（正常使用） */
+        ACTIVE,
+        /** 已禁用 */
+        DISABLED,
+        /** 已注销 */
+        DELETED
+    }
+}

--- a/ihub-module-iam/src/main/java/pub/ihub/module/iam/UserService.java
+++ b/ihub-module-iam/src/main/java/pub/ihub/module/iam/UserService.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.module.iam;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 用户服务（内存实现，供开发/测试环境使用）。
+ *
+ * <p>生产环境应替换为持久化实现（如 MyBatis Plus）。
+ *
+ * @author IHub
+ * @since 0.1.0
+ */
+public class UserService {
+
+    private final Map<String, User> store = new ConcurrentHashMap<>();
+    private final Map<String, String> usernameIndex = new ConcurrentHashMap<>();
+
+    /**
+     * 创建用户。
+     *
+     * @param username 用户名（不能重复）
+     * @param email    邮箱（可为 null）
+     * @param roles    初始角色列表
+     * @return 创建成功的用户
+     * @throws IllegalArgumentException 用户名已存在
+     */
+    public User createUser(String username, String email, List<String> roles) {
+        if (username == null || username.isBlank()) {
+            throw new IllegalArgumentException("用户名不能为空");
+        }
+        if (usernameIndex.containsKey(username)) {
+            throw new IllegalArgumentException("用户名已存在: " + username);
+        }
+        String userId = UUID.randomUUID().toString();
+        User user = new User(
+            userId, username, email,
+            User.UserStatus.ACTIVE,
+            roles == null ? List.of() : List.copyOf(roles),
+            Instant.now()
+        );
+        store.put(userId, user);
+        usernameIndex.put(username, userId);
+        return user;
+    }
+
+    /**
+     * 按 ID 查找用户。
+     */
+    public Optional<User> findById(String userId) {
+        return Optional.ofNullable(store.get(userId));
+    }
+
+    /**
+     * 按用户名查找用户。
+     */
+    public Optional<User> findByUsername(String username) {
+        String id = usernameIndex.get(username);
+        return id != null ? Optional.ofNullable(store.get(id)) : Optional.empty();
+    }
+
+    /**
+     * 列出所有用户。
+     */
+    public List<User> listAll() {
+        return List.copyOf(store.values());
+    }
+
+    /**
+     * 为用户分配角色。
+     *
+     * @param userId  用户 ID
+     * @param roleIds 要追加的角色 ID 列表
+     * @return 更新后的用户
+     * @throws IllegalArgumentException 用户不存在
+     */
+    public User assignRoles(String userId, List<String> roleIds) {
+        User user = store.get(userId);
+        if (user == null) {
+            throw new IllegalArgumentException("用户不存在: " + userId);
+        }
+        List<String> merged = new ArrayList<>(user.roles());
+        roleIds.forEach(r -> {
+            if (!merged.contains(r)) {
+                merged.add(r);
+            }
+        });
+        User updated = new User(user.userId(), user.username(), user.email(),
+            user.status(), List.copyOf(merged), user.createdAt());
+        store.put(userId, updated);
+        return updated;
+    }
+
+    /**
+     * 变更用户状态。
+     */
+    public User changeStatus(String userId, User.UserStatus newStatus) {
+        User user = store.get(userId);
+        if (user == null) {
+            throw new IllegalArgumentException("用户不存在: " + userId);
+        }
+        User updated = new User(user.userId(), user.username(), user.email(),
+            newStatus, user.roles(), user.createdAt());
+        store.put(userId, updated);
+        return updated;
+    }
+}

--- a/ihub-module-iam/src/main/resources/META-INF/ihub/module-descriptor.json
+++ b/ihub-module-iam/src/main/resources/META-INF/ihub/module-descriptor.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://ihub.pub/schemas/module-descriptor/v1",
+  "id": "iam-user",
+  "name": "用户管理模块",
+  "name_en": "User Management Module",
+  "version": "0.1.0",
+  "domain": "iam",
+  "description": "提供用户账号生命周期管理：注册、认证、档案、状态变更",
+  "ai_context": "## 集成模式\n引入 `ihub-module-iam` 依赖，添加 `@EnableIHubUserModule` 注解或依赖自动配置。\n\n## API 清单\n- `POST /api/users` — 创建用户\n- `GET /api/users/{id}` — 查询用户详情\n- `PUT /api/users/{id}` — 更新用户信息\n- `DELETE /api/users/{id}` — 注销用户\n- `POST /api/users/{id}/roles` — 分配角色\n- `GET /api/users?keyword=&roleId=&page=&size=` — 分页查询\n\n## 配置要点\n- `ihub.module.user.password-encoder`: 密码加密器（默认 BCrypt）\n- `ihub.module.user.email-verification`: 是否开启邮箱验证（默认 false）\n- `ihub.module.user.default-role`: 新用户默认角色 ID\n\n## 依赖关系\n- 依赖 `iam-role` 模块进行角色分配\n- 依赖 `data-orm-mybatis-plus`（libs catalog）进行数据持久化\n- 依赖 `security-authn-spring`（libs catalog）进行认证集成\n\n## 约束与限制\n- 用户名全局唯一\n- 密码最低 8 位，含大小写和数字\n- 删除用户前需先解除所有角色绑定\n\n## 常见陷阱\n- 未配置 `default-role` 导致新用户无任何权限\n- 忘记开启邮箱验证导致测试账号泛滥\n- 用户 ID 与租户 ID 混淆（多租户场景）",
+  "capabilities": [
+    {
+      "id": "user.create",
+      "name": "创建用户",
+      "type": "api",
+      "description": "创建新用户账号，支持设置初始角色",
+      "input_schema": {
+        "type": "object",
+        "required": ["username", "password"],
+        "properties": {
+          "username": { "type": "string", "minLength": 3, "maxLength": 32 },
+          "password": { "type": "string", "minLength": 8 },
+          "email": { "type": "string", "format": "email" },
+          "roles": { "type": "array", "items": { "type": "string" } }
+        }
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "userId": { "type": "string" },
+          "username": { "type": "string" },
+          "status": { "type": "string", "enum": ["active", "pending"] }
+        }
+      }
+    },
+    {
+      "id": "user.query",
+      "name": "查询用户",
+      "type": "api",
+      "description": "按条件分页查询用户列表",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "keyword": { "type": "string" },
+          "roleId": { "type": "string" },
+          "page": { "type": "integer", "minimum": 0 },
+          "size": { "type": "integer", "minimum": 1, "maximum": 100 }
+        }
+      }
+    },
+    {
+      "id": "user.status-changed",
+      "name": "用户状态变更事件",
+      "type": "event",
+      "description": "用户状态发生变化时发布的领域事件（激活、禁用、注销）",
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "userId": { "type": "string" },
+          "oldStatus": { "type": "string" },
+          "newStatus": { "type": "string" },
+          "timestamp": { "type": "string", "format": "date-time" }
+        }
+      }
+    }
+  ],
+  "dependencies": [
+    {
+      "moduleId": "iam-role",
+      "required": false,
+      "reason": "角色分配功能需要角色模块；若不需要 RBAC 可不引入"
+    }
+  ],
+  "maven": {
+    "group": "pub.ihub.module",
+    "artifact": "ihub-module-iam"
+  },
+  "gradle_ref": "ihub-module-iam",
+  "config_prefix": "ihub.module.user",
+  "tags": ["iam", "user", "authentication", "account"],
+  "status": "planned",
+  "mcp_tools": [
+    {
+      "name": "createUser",
+      "description": "创建用户账号。需要提供用户名和密码，可选邮箱和初始角色列表。返回新建用户的 ID 和初始状态",
+      "input_schema": {
+        "type": "object",
+        "required": ["username", "password"],
+        "properties": {
+          "username": { "type": "string" },
+          "password": { "type": "string" },
+          "email": { "type": "string" },
+          "roles": { "type": "array", "items": { "type": "string" } }
+        }
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "userId": { "type": "string" },
+          "status": { "type": "string" }
+        }
+      }
+    },
+    {
+      "name": "queryUsers",
+      "description": "按关键字或角色分页查询用户列表。返回符合条件的用户摘要列表",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "keyword": { "type": "string" },
+          "roleId": { "type": "string" },
+          "page": { "type": "integer" },
+          "size": { "type": "integer" }
+        }
+      }
+    },
+    {
+      "name": "assignRole",
+      "description": "为指定用户分配一个或多个角色。角色立即生效",
+      "input_schema": {
+        "type": "object",
+        "required": ["userId", "roleIds"],
+        "properties": {
+          "userId": { "type": "string" },
+          "roleIds": { "type": "array", "items": { "type": "string" } }
+        }
+      },
+      "output_schema": {
+        "type": "object",
+        "properties": {
+          "success": { "type": "boolean" }
+        }
+      }
+    }
+  ]
+}

--- a/ihub-module-iam/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/ihub-module-iam/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+pub.ihub.module.iam.IHubIamAutoConfiguration

--- a/ihub-module-iam/src/test/java/pub/ihub/module/iam/IHubIamAutoConfigurationTest.java
+++ b/ihub-module-iam/src/test/java/pub/ihub/module/iam/IHubIamAutoConfigurationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.module.iam;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * {@link IHubIamAutoConfiguration} 集成测试。
+ *
+ * @author IHub
+ * @since 0.1.0
+ */
+class IHubIamAutoConfigurationTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(IHubIamAutoConfiguration.class));
+
+    @Test
+    void registersUserServiceByDefault() {
+        runner.run(ctx -> {
+            assertTrue(ctx.containsBean("userService"));
+            assertNotNull(ctx.getBean(UserService.class));
+        });
+    }
+
+    @Test
+    void doesNotOverrideCustomUserService() {
+        runner.withBean("customUserService", UserService.class, UserService::new)
+            .run(ctx -> {
+                // Should have both (the auto-configured one is suppressed by @ConditionalOnMissingBean)
+                // Actually @ConditionalOnMissingBean means auto-config bean is NOT created
+                // when any UserService bean exists
+                assertEquals(1, ctx.getBeansOfType(UserService.class).size());
+            });
+    }
+}

--- a/ihub-module-iam/src/test/java/pub/ihub/module/iam/UserServiceTest.java
+++ b/ihub-module-iam/src/test/java/pub/ihub/module/iam/UserServiceTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pub.ihub.module.iam;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * {@link UserService} 单元测试。
+ *
+ * @author IHub
+ * @since 0.1.0
+ */
+class UserServiceTest {
+
+    private UserService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new UserService();
+    }
+
+    // ---- createUser ----
+
+    @Test
+    void createUserSuccess() {
+        User user = service.createUser("alice", "alice@example.com", List.of("ROLE_USER"));
+        assertNotNull(user.userId());
+        assertEquals("alice", user.username());
+        assertEquals("alice@example.com", user.email());
+        assertEquals(User.UserStatus.ACTIVE, user.status());
+        assertEquals(List.of("ROLE_USER"), user.roles());
+        assertNotNull(user.createdAt());
+    }
+
+    @Test
+    void createUserWithNullRoles() {
+        User user = service.createUser("bob", null, null);
+        assertTrue(user.roles().isEmpty());
+    }
+
+    @Test
+    void createUserBlankUsernameThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> service.createUser("  ", null, null));
+    }
+
+    @Test
+    void createUserNullUsernameThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> service.createUser(null, null, null));
+    }
+
+    @Test
+    void createUserDuplicateUsernameThrows() {
+        service.createUser("charlie", null, null);
+        assertThrows(IllegalArgumentException.class,
+            () -> service.createUser("charlie", null, null));
+    }
+
+    // ---- findById ----
+
+    @Test
+    void findByIdExists() {
+        User created = service.createUser("dave", null, null);
+        Optional<User> found = service.findById(created.userId());
+        assertTrue(found.isPresent());
+        assertEquals("dave", found.get().username());
+    }
+
+    @Test
+    void findByIdNotFound() {
+        assertTrue(service.findById("no-such-id").isEmpty());
+    }
+
+    // ---- findByUsername ----
+
+    @Test
+    void findByUsernameExists() {
+        service.createUser("eve", "eve@example.com", null);
+        Optional<User> found = service.findByUsername("eve");
+        assertTrue(found.isPresent());
+        assertEquals("eve@example.com", found.get().email());
+    }
+
+    @Test
+    void findByUsernameNotFound() {
+        assertTrue(service.findByUsername("ghost").isEmpty());
+    }
+
+    // ---- listAll ----
+
+    @Test
+    void listAllEmpty() {
+        assertTrue(service.listAll().isEmpty());
+    }
+
+    @Test
+    void listAllReturnsAll() {
+        service.createUser("u1", null, null);
+        service.createUser("u2", null, null);
+        assertEquals(2, service.listAll().size());
+    }
+
+    // ---- assignRoles ----
+
+    @Test
+    void assignRolesAddsNewRoles() {
+        User created = service.createUser("frank", null, List.of("ROLE_USER"));
+        User updated = service.assignRoles(created.userId(), List.of("ROLE_ADMIN"));
+        assertEquals(2, updated.roles().size());
+        assertTrue(updated.roles().contains("ROLE_ADMIN"));
+    }
+
+    @Test
+    void assignRolesSkipsDuplicates() {
+        User created = service.createUser("grace", null, List.of("ROLE_USER"));
+        User updated = service.assignRoles(created.userId(), List.of("ROLE_USER", "ROLE_ADMIN"));
+        assertEquals(2, updated.roles().size());
+    }
+
+    @Test
+    void assignRolesUserNotFoundThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> service.assignRoles("no-such-id", List.of("ROLE_USER")));
+    }
+
+    // ---- changeStatus ----
+
+    @Test
+    void changeStatusDisabled() {
+        User created = service.createUser("henry", null, null);
+        User updated = service.changeStatus(created.userId(), User.UserStatus.DISABLED);
+        assertEquals(User.UserStatus.DISABLED, updated.status());
+    }
+
+    @Test
+    void changeStatusDeleted() {
+        User created = service.createUser("ivan", null, null);
+        User updated = service.changeStatus(created.userId(), User.UserStatus.DELETED);
+        assertEquals(User.UserStatus.DELETED, updated.status());
+    }
+
+    @Test
+    void changeStatusUserNotFoundThrows() {
+        assertThrows(IllegalArgumentException.class,
+            () -> service.changeStatus("no-such-id", User.UserStatus.DISABLED));
+    }
+
+    // ---- User record / UserStatus enum ----
+
+    @Test
+    void userStatusAllValues() {
+        assertEquals(4, User.UserStatus.values().length);
+    }
+}

--- a/schema/module-descriptor-v1.json
+++ b/schema/module-descriptor-v1.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ihub.pub/schemas/module-descriptor/v1",
+  "title": "IHub Module Descriptor",
+  "description": "IHub 业务模块描述符 v1 规范。每个模块在 META-INF/ihub/module-descriptor.json 提供此文件",
+  "type": "object",
+  "required": ["id", "name", "domain", "description", "status"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "模块唯一标识，建议格式：{domain}-{name}，如 iam-user",
+      "pattern": "^[a-z][a-z0-9-]*$"
+    },
+    "name": {
+      "type": "string",
+      "description": "模块中文名称"
+    },
+    "name_en": {
+      "type": "string",
+      "description": "模块英文名称"
+    },
+    "version": {
+      "type": "string",
+      "description": "模块版本号"
+    },
+    "domain": {
+      "type": "string",
+      "description": "所属业务领域，如 iam / organization / content"
+    },
+    "description": {
+      "type": "string",
+      "description": "一句话功能描述"
+    },
+    "ai_context": {
+      "type": "string",
+      "description": "面向 LLM 的详细上下文（Markdown 格式）：集成方式、API 清单、配置要点、常见陷阱"
+    },
+    "capabilities": {
+      "type": "array",
+      "description": "模块提供的能力列表",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "type", "description"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "type": {
+            "type": "string",
+            "enum": ["api", "event", "schedule", "mcp_tool"]
+          },
+          "description": { "type": "string" },
+          "input_schema": { "type": "object" },
+          "output_schema": { "type": "object" }
+        }
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "description": "模块间依赖声明",
+      "items": {
+        "type": "object",
+        "required": ["moduleId", "required"],
+        "properties": {
+          "moduleId": { "type": "string" },
+          "required": { "type": "boolean" },
+          "reason": { "type": "string" }
+        }
+      }
+    },
+    "maven": {
+      "type": "object",
+      "description": "Maven 坐标",
+      "properties": {
+        "group": { "type": "string" },
+        "artifact": { "type": "string" }
+      }
+    },
+    "gradle_ref": {
+      "type": "string",
+      "description": "libs.versions.toml 别名"
+    },
+    "config_prefix": {
+      "type": "string",
+      "description": "Spring 配置前缀，如 ihub.module.user"
+    },
+    "starter_class": {
+      "type": "string",
+      "description": "Spring Boot 自动配置类全名"
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "status": {
+      "type": "string",
+      "enum": ["planned", "experimental", "stable", "deprecated"],
+      "description": "模块状态"
+    },
+    "mcp_tools": {
+      "type": "array",
+      "description": "AI 可通过 MCP 调用的工具列表",
+      "items": {
+        "type": "object",
+        "required": ["name", "description"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "工具名称（全局唯一，camelCase）"
+          },
+          "description": {
+            "type": "string",
+            "description": "AI 理解工具用途的描述（清晰准确，影响 AI 调用准确率）"
+          },
+          "input_schema": { "type": "object" },
+          "output_schema": { "type": "object" }
+        }
+      }
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
 plugins {
-    id("pub.ihub.plugin.ihub-settings") version "1.9.3"
+    id("pub.ihub.plugin.ihub-settings") version "1.9.5"
 }
+
+include("ihub-module-core", "ihub-module-iam")


### PR DESCRIPTION
- 新增 ModuleDescriptor 模块描述符 record（含状态枚举）
- 新增 ModuleRegistry 注册表（classpath 扫描 + 手动注册）
- 新增 ModuleCapability/ModuleDependency/McpToolDefinition 数据模型
- ModuleRegistry 新增 getClassLoader() 可覆写方法提升可测试性
- 新增测试资源 module-descriptor.json，补充测试覆盖率至 91.7%/100%
- 新增 JSON Schema 定义及 ihub-module-iam 模块骨架